### PR TITLE
Missing rbac for provisioner sidecar

### DIFF
--- a/resources/deployment.yaml
+++ b/resources/deployment.yaml
@@ -35,25 +35,16 @@ spec:
       containers:
       - name: objectstorage-sample-driver
         image: quay.io/containerobjectstorage/objectstorage-sample-driver:latest
-        resources:
-          limits:
-            cpu: 1
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        args:
+          - "--listen-address=$(LISTEN_ADDRESS)"
+          - "--s3-endpoint=$(S3_ENDPOINT)"
+          - "--access-key=$(ACCESS_KEY)"
+          - "--secret-key=$(SECRET_KEY)"
         envFrom:
         - secretRef:
             name: objectstorage-provisioner
       - name: objectstorage-provisioner-sidecar
         image: quay.io/containerobjectstorage/objectstorage-sidecar:latest
-        resources:
-          limits:
-            cpu: 1
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 100Mi
         env:
         - name: CONNECT_ADDRESS
           valueFrom:

--- a/resources/rbac.yaml
+++ b/resources/rbac.yaml
@@ -16,6 +16,12 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["list", "watch", "create", "update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["objectstorage.k8s.io"]
+  resources: ["bucketaccesses"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/resources/secret.yaml
+++ b/resources/secret.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: container-object-storage-interface-provisioner
 type: Opaque
 stringData:
-  LISTEN_ADDRESS: 0.0.0.0:9000
+  LISTEN_ADDRESS: tcp://0.0.0.0:9000
 data:
   # set to space
   S3_ENDPOINT: IA==


### PR DESCRIPTION
1. The provisioner sidecar pod is failing without those settings in rbac
2. Passing flags for s3 endpoint + credentials to the sample driver
3. LISTEN_ADDRESS needs the tcp:// prefix