### PR TITLE
add identity server to sample-driver

### DIFF
--- a/cmd/sample-driver/driver-server.go
+++ b/cmd/sample-driver/driver-server.go
@@ -35,33 +35,13 @@ import (
 	cosi "sigs.k8s.io/container-object-storage-interface-spec"
 )
 
-var (
-	PROVISIONER_NAME = "sample-provisioner.objectstorage.k8s.io"
-	VERSION          = "dev"
-)
-
 type DriverServer struct {
-	Name, Version string
 	S3Client      *minio.Client
 	S3AdminClient *madmin.AdminClient
 }
 
-func (ds *DriverServer) ProvisionerGetInfo(context.Context, *cosi.ProvisionerGetInfoRequest) (*cosi.ProvisionerGetInfoResponse, error) {
-	rsp := &cosi.ProvisionerGetInfoResponse{}
-	rsp.Name = fmt.Sprintf("%s-%s", ds.Name, ds.Version)
-	return rsp, nil
-}
-
 func (ds DriverServer) ProvisionerCreateBucket(ctx context.Context, req *cosi.ProvisionerCreateBucketRequest) (*cosi.ProvisionerCreateBucketResponse, error) {
 	klog.Infof("Using minio to create Backend Bucket")
-
-	if ds.Name == "" {
-		return nil, status.Error(codes.Unavailable, "Driver name not configured")
-	}
-
-	if ds.Version == "" {
-		return nil, status.Error(codes.Unavailable, "Driver is missing version")
-	}
 
 	s3 := req.Protocol.GetS3()
 	if s3 == nil {

--- a/cmd/sample-driver/identity-server.go
+++ b/cmd/sample-driver/identity-server.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/minio/minio-go"
+	"github.com/minio/minio/pkg/madmin"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cosi "sigs.k8s.io/container-object-storage-interface-spec"
+)
+
+var (
+	PROVISIONER_NAME = "sample-provisioner.objectstorage.k8s.io"
+	VERSION          = "dev"
+)
+
+type IdentityServer struct {
+	Name, Version string
+	S3Client      *minio.Client
+	S3AdminClient *madmin.AdminClient
+}
+
+func (id *IdentityServer) ProvisionerGetInfo(context.Context, *cosi.ProvisionerGetInfoRequest) (*cosi.ProvisionerGetInfoResponse, error) {
+	if id.Name == "" {
+		return nil, status.Error(codes.Unavailable, "Driver name not configured")
+	}
+
+	if id.Version == "" {
+		return nil, status.Error(codes.Unavailable, "Driver is missing version")
+	}
+	rsp := &cosi.ProvisionerGetInfoResponse{}
+	rsp.Name = fmt.Sprintf("%s-%s", id.Name, id.Version)
+	return rsp, nil
+}

--- a/cmd/sample-driver/sample-driver.go
+++ b/cmd/sample-driver/sample-driver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/container-object-storage-interface-provisioner-sidecar/pkg/grpcserver"
@@ -119,9 +118,10 @@ func run(args []string, endpoint string) error {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	cds := DriverServer{Name: PROVISIONER_NAME, Version: VERSION, S3Client: minioClient, S3AdminClient: minioAdminClient}
+	cds := DriverServer{S3Client: minioClient, S3AdminClient: minioAdminClient}
+	ids := IdentityServer{Name: PROVISIONER_NAME, Version: VERSION}
 	s := grpcserver.NewNonBlockingGRPCServer()
-	s.Start(endpoint, &cds)
+	s.Start(endpoint, &cds, &ids)
 	s.Wait()
 	return nil
 }


### PR DESCRIPTION
The sample driver was missing the identity server, and as a result, that step of the deployment process was failing. This PR aims to resolve this issue by separating ProvisionerGetInfo from the driver-server and creating the identity-server.

cc @wlan0 @YiannisGkoufas 
