### PR TITLE
Migrate away from google.com gcp project k8s-testimages

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,15 +3,15 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-- name: "gcr.io/k8s-testimages/gcb-docker-gcloud:v20220617-174ad91c3a"
+- name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a"
   entrypoint: make
   args: ['build']
-  env: 
+  env:
   - GIT_TAG=${_GIT_TAG}
   - PULL_BASE_REF=${_PULL_BASE_REF}
-- name: "gcr.io/k8s-testimages/gcb-docker-gcloud:v20220617-174ad91c3a"
+- name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a"
   entrypoint: make
   args: ['push']
-  env: 
+  env:
   - GIT_TAG=${_GIT_TAG}
   - PULL_BASE_REF=${_PULL_BASE_REF}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Migrate away from google.com gcp project k8s-testimages

Related to https://github.com/kubernetes/k8s.io/issues/1523


/assign @ameukam @msau42

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

