### PR TITLE
Fix reconciliation logic for existing and deleted objects

### DIFF
--- a/pkg/bucket/bucket_controller.go
+++ b/pkg/bucket/bucket_controller.go
@@ -222,6 +222,12 @@ func (b *BucketListener) Update(ctx context.Context, old, new *v1alpha1.Bucket) 
 		if err = b.handleDeletion(ctx, bucket); err != nil {
 			return err
 		}
+	} else {
+		// Trigger the Add logic to ensure that the Bucket is properly reconciled
+		err := b.Add(ctx, bucket)
+		if err != nil {
+			return b.recordError(bucket, v1.EventTypeWarning, events.FailedGrantAccess, err)
+		}
 	}
 
 	klog.V(3).InfoS("Update Bucket success",

--- a/pkg/bucket/bucket_controller.go
+++ b/pkg/bucket/bucket_controller.go
@@ -69,6 +69,12 @@ func (b *BucketListener) Add(ctx context.Context, inputBucket *v1alpha1.Bucket) 
 
 	var err error
 
+	if !bucket.GetDeletionTimestamp().IsZero() {
+		if err = b.handleDeletion(ctx, bucket); err != nil {
+			return err
+		}
+	}
+
 	klog.V(3).InfoS("Add Bucket",
 		"name", bucket.ObjectMeta.Name)
 
@@ -213,48 +219,7 @@ func (b *BucketListener) Update(ctx context.Context, old, new *v1alpha1.Bucket) 
 	var err error
 
 	if !bucket.GetDeletionTimestamp().IsZero() {
-		if controllerutil.ContainsFinalizer(bucket, consts.BABucketFinalizer) {
-			bucketClaimNs := bucket.Spec.BucketClaim.Namespace
-			bucketClaimName := bucket.Spec.BucketClaim.Name
-			bucketAccessList, err := b.bucketAccesses(bucketClaimNs).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				klog.V(3).ErrorS(err, "Error fetching BucketAccessList",
-					"bucket", bucket.ObjectMeta.Name)
-				return err
-			}
-
-			for _, bucketAccess := range bucketAccessList.Items {
-				if strings.EqualFold(bucketAccess.Spec.BucketClaimName, bucketClaimName) {
-					err = b.bucketAccesses(bucketClaimNs).Delete(ctx, bucketAccess.Name, metav1.DeleteOptions{})
-					if err != nil {
-						klog.V(3).ErrorS(err, "Error deleting BucketAccess",
-							"name", bucketAccess.Name,
-							"bucket", bucket.ObjectMeta.Name)
-						return err
-					}
-				}
-			}
-
-			klog.V(5).Infof("Successfully deleted dependent bucketAccess of bucket:%s", bucket.ObjectMeta.Name)
-
-			controllerutil.RemoveFinalizer(bucket, consts.BABucketFinalizer)
-			klog.V(5).Infof("Successfully removed finalizer: %s of bucket: %s", consts.BABucketFinalizer, bucket.ObjectMeta.Name)
-		}
-
-		if controllerutil.ContainsFinalizer(bucket, consts.BucketFinalizer) {
-			err = b.deleteBucketOp(ctx, bucket)
-			if err != nil {
-				return b.recordError(bucket, v1.EventTypeWarning, events.FailedDeleteBucket, err)
-			}
-
-			controllerutil.RemoveFinalizer(bucket, consts.BucketFinalizer)
-			klog.V(5).Infof("Successfully removed finalizer: %s of bucket: %s", consts.BucketFinalizer, bucket.ObjectMeta.Name)
-		}
-
-		_, err = b.buckets().Update(ctx, bucket, metav1.UpdateOptions{})
-		if err != nil {
-			klog.V(3).ErrorS(err, "Error updating bucket after removing finalizers",
-				"bucket", bucket.ObjectMeta.Name)
+		if err = b.handleDeletion(ctx, bucket); err != nil {
 			return err
 		}
 	}
@@ -265,7 +230,7 @@ func (b *BucketListener) Update(ctx context.Context, old, new *v1alpha1.Bucket) 
 	return nil
 }
 
-// Delete attemps to delete a bucket. This function must be idempotent
+// Delete attempts to delete a bucket. This function must be idempotent
 // Delete function is called when the bucket was not able to add finalizers while creation.
 // Hence we will take care of removing the BucketClaim finalizer before deleting the Bucket object.
 // Return values
@@ -363,6 +328,55 @@ func (b *BucketListener) deleteBucketOp(ctx context.Context, bucket *v1alpha1.Bu
 		}
 
 		klog.V(5).Infof("Successfully removed finalizer: %s from bucketClaim: %s for bucket: %s", consts.BCFinalizer, bucketClaim.ObjectMeta.Name, bucket.ObjectMeta.Name)
+	}
+
+	return nil
+}
+
+func (b *BucketListener) handleDeletion(ctx context.Context, bucket *v1alpha1.Bucket) error {
+	var err error
+
+	// Remove BABucketFinalizer and delete associated BucketAccess resources
+	if controllerutil.ContainsFinalizer(bucket, consts.BABucketFinalizer) {
+		bucketClaimNs := bucket.Spec.BucketClaim.Namespace
+		bucketClaimName := bucket.Spec.BucketClaim.Name
+		bucketAccessList, err := b.bucketAccesses(bucketClaimNs).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			klog.V(3).ErrorS(err, "Error fetching BucketAccessList", "bucket", bucket.ObjectMeta.Name)
+			return err
+		}
+
+		for _, bucketAccess := range bucketAccessList.Items {
+			if strings.EqualFold(bucketAccess.Spec.BucketClaimName, bucketClaimName) {
+				err = b.bucketAccesses(bucketClaimNs).Delete(ctx, bucketAccess.Name, metav1.DeleteOptions{})
+				if err != nil {
+					klog.V(3).ErrorS(err, "Error deleting BucketAccess", "name", bucketAccess.Name, "bucket", bucket.ObjectMeta.Name)
+					return err
+				}
+			}
+		}
+
+		klog.V(5).Infof("Successfully deleted dependent bucketAccess of bucket:%s", bucket.ObjectMeta.Name)
+
+		controllerutil.RemoveFinalizer(bucket, consts.BABucketFinalizer)
+		klog.V(5).Infof("Successfully removed finalizer: %s of bucket: %s", consts.BABucketFinalizer, bucket.ObjectMeta.Name)
+	}
+
+	// Remove BucketFinalizer and delete the bucket
+	if controllerutil.ContainsFinalizer(bucket, consts.BucketFinalizer) {
+		err = b.deleteBucketOp(ctx, bucket)
+		if err != nil {
+			return b.recordError(bucket, v1.EventTypeWarning, events.FailedDeleteBucket, err)
+		}
+
+		controllerutil.RemoveFinalizer(bucket, consts.BucketFinalizer)
+		klog.V(5).Infof("Successfully removed finalizer: %s of bucket: %s", consts.BucketFinalizer, bucket.ObjectMeta.Name)
+
+		_, err = b.buckets().Update(ctx, bucket, metav1.UpdateOptions{})
+		if err != nil {
+			klog.V(3).ErrorS(err, "Error updating bucket after removing finalizers", "bucket", bucket.ObjectMeta.Name)
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/bucketaccess/bucketaccess_controller.go
+++ b/pkg/bucketaccess/bucketaccess_controller.go
@@ -315,6 +315,12 @@ func (bal *BucketAccessListener) Update(ctx context.Context, old, new *v1alpha1.
 		if err != nil {
 			return bal.recordError(bucketAccess, v1.EventTypeWarning, events.FailedRevokeAccess, err)
 		}
+	} else {
+		// Trigger the Add logic to ensure that the BucketAccess is properly reconciled
+		err := bal.Add(ctx, bucketAccess)
+		if err != nil {
+			return bal.recordError(bucketAccess, v1.EventTypeWarning, events.FailedGrantAccess, err)
+		}
 	}
 
 	klog.V(3).InfoS("Update BucketAccess success",

--- a/pkg/bucketaccess/bucketaccess_controller.go
+++ b/pkg/bucketaccess/bucketaccess_controller.go
@@ -69,6 +69,13 @@ func NewBucketAccessListener(driverName string, client cosi.ProvisionerClient) *
 func (bal *BucketAccessListener) Add(ctx context.Context, inputBucketAccess *v1alpha1.BucketAccess) error {
 	bucketAccess := inputBucketAccess.DeepCopy()
 
+	if !bucketAccess.GetDeletionTimestamp().IsZero() {
+		// If the bucketAccess has a deletion timestamp, handle it as a deletion
+		klog.V(3).InfoS("BucketAccess has deletion timestamp, handling deletion",
+			"name", bucketAccess.ObjectMeta.Name)
+		return bal.deleteBucketAccessOp(ctx, bucketAccess)
+	}
+
 	if bucketAccess.Status.AccessGranted && bucketAccess.Status.AccountID != "" {
 		klog.V(3).InfoS("BucketAccess already exists", bucketAccess.ObjectMeta.Name)
 		return nil


### PR DESCRIPTION
This PR addresses two cases:
- **Controller Restarts:**
        When the controller restarts, it does not handle deletions for removed objects.
        Specifically, when an object with a deletion timestamp is passed into the Add() method, the deletion process was not handled correctly.

- **Recreation of Objects:**
        The recreation of objects is not functioning as expected. For example, when an object is created, deleted, and then created again.
        In this scenario, the object may enter the Update method, where the creation process was not being handled properly.