### PR TITLE
Update README.md to redirect to new monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# MOVED: **This repo has been moved to https://github.com/kubernetes-sigs/container-object-storage-interface : see `sidecar` directory**
+
+
 # Container Object Storage Provisioner Sidecar
 
 Container Object Storage Interface (COSI) provisioner sidecar is responsible to manage lifecycle of COSI objects and is


### PR DESCRIPTION
Update readme to redirect users to new monorepo:
https://github.com/kubernetes-sigs/container-object-storage-interface